### PR TITLE
Change Threader to work with Subjects

### DIFF
--- a/pysellus/threader.py
+++ b/pysellus/threader.py
@@ -1,17 +1,21 @@
+import rx.subjects as subjects
+
 from threading import Thread
 
 
 def build_threads(stream_to_observers, fn):
     threads = []
     for k, v in stream_to_observers.items():
+        subject = subjects.Subject()
         for e in v:
-            threads.append(make_thread(fn, k, e))
+            subject.subscribe(e)
+        threads.append(make_thread(fn, k, subject))
 
     return threads
 
 
-def make_thread(fn, stream, observer):
-    return Thread(target=fn, args=(stream, observer))
+def make_thread(fn, stream, subject):
+    return Thread(target=fn, args=(stream, subject))
 
 
 def launch_threads(threads):

--- a/spec/threader_spec.py
+++ b/spec/threader_spec.py
@@ -8,7 +8,7 @@ from doublex_expects import have_been_called
 from pysellus import threader
 
 with description('the threader module'):
-    with it('should create as many threads as the sum of len(values) of the supplied dict'):
+    with it('should create as many threads as streams in the supplied dict'):
         a_stream = Mock()
         another_stream = Mock()
 
@@ -23,18 +23,16 @@ with description('the threader module'):
 
         threads = threader.build_threads(streams_to_observers, foo)
 
-        expected_length = sum(
-            len(fn_list) for fn_list in streams_to_observers.values()
-        )
+        expected_length = len(streams_to_observers)
 
         expect(len(threads)).to(be(expected_length))
 
     with it('should create a properly initialized thread'):
         stream = Mock()
-        observer = Spy()
+        subject = Spy()
         target = Spy().target_function
 
-        thread = threader.make_thread(target, stream, observer)
+        thread = threader.make_thread(target, stream, subject)
 
         thread.start()
         thread.join()
@@ -43,7 +41,7 @@ with description('the threader module'):
 
     with it('should call the target function with the correct arguments'):
         stream = Mock()
-        observer = Spy()
+        subject = Spy()
         que = queue.Queue(maxsize=1)
 
         # Return a list with the stream and the observer fn
@@ -57,7 +55,7 @@ with description('the threader module'):
         # as a parameter to make_thread
         target_partial = partial(target_wrapper, que)
 
-        thread = threader.make_thread(target_partial, stream, observer)
+        thread = threader.make_thread(target_partial, stream, subject)
 
         thread.start()
         thread.join()
@@ -66,7 +64,7 @@ with description('the threader module'):
         # result is [stream, observer]
 
         expect(result[0]).to(be(stream))
-        expect(result[1]).to(be(observer))
+        expect(result[1]).to(be(subject))
 
     with it('should call `run` on every thread passed to the launch_threads function'):
         a_thread = Spy()


### PR DESCRIPTION
Threader used to create as many threads as the sum of all the function
lists in the given observable map. This worked ok for a quick prototype
but could get ugly when a single stream has a lot of functions applied
to it.

Adding subjects, we cut the number of threads to a minimum, that is, one
thread per stream in the map.

Instead of creating a single thread per function, we subscribe each
function to a subject (proxy), and then create a thread per subject.

I modified the tests too to account for the change in the number of
threads too.

Potential problems:
- Threader now knows about rx.subjects. This could be changed to
  make threader same as before and make registrar work with them.
  But this just shifts the problem over to registrar, and makes
  the structure of `stream_to_observers` more complex.
