### PR TITLE
Add option to launch pysellus from a single file

### DIFF
--- a/pysellus/loader.py
+++ b/pysellus/loader.py
@@ -4,15 +4,33 @@ from inspect import isfunction
 from importlib import import_module
 
 
-def load(directory):
+def load(path):
+    if _is_python_file(path):
+        sys.path.insert(0, os.path.dirname(path))
+        module = import_module(_get_module_name_from_path(path))
+        return _get_checks_from_module(module)
+
     functions = []
+    for module in _get_modules(path):
+        functions += _get_checks_from_module(module)
 
-    for module in _get_modules(directory):
-        for name in dir(module):
-            value = getattr(module, name)
-            if isfunction(value) and name.startswith('pscheck_'):
-                functions.append(value)
+    return functions
 
+
+def _get_module_name_from_path(path):
+    return _remove_file_extension(path.split('/')[-1])
+
+
+def _get_checks_from_module(module):
+    """
+    Gets all setup functions from the given module.
+    Setup functions are required to start with 'pscheck_'
+    """
+    functions = []
+    for name in dir(module):
+        value = getattr(module, name)
+        if isfunction(value) and name.startswith('pscheck_'):
+            functions.append(value)
     return functions
 
 

--- a/spec/loader_spec.py
+++ b/spec/loader_spec.py
@@ -4,14 +4,20 @@ from spec.custom_matchers.contain_exactly_function_called import contain_exactly
 
 from pysellus import loader
 
-with description('the loader module loads all top-level functions in a directory'):
+with description('the loader module loads all top-level functions in a directory or file'):
     with it('should load every function when there is only one file'):
         expect(loader.load('spec/fixtures/one_file/')).to(
             contain_exactly_function_called('pscheck_a_function',
                                             'pscheck_another_function')
         )
 
-    with it('should load every function  when there is more than one file'):
+    with it('should load every function of the specified file'):
+        expect(loader.load('spec/fixtures/multiple_files/file_1.py')).to(
+            contain_exactly_function_called('pscheck_file_1_function_a',
+                                            'pscheck_file_1_function_b')
+        )
+
+    with it('should load every function when there is more than one file'):
         expect(loader.load('spec/fixtures/multiple_files/')).to(
             contain_exactly_function_called('pscheck_file_1_function_a',
                                             'pscheck_file_1_function_b',
@@ -21,7 +27,7 @@ with description('the loader module loads all top-level functions in a directory
                                             'pscheck_file_3_function_b')
         )
 
-    with it("shouldn't load private functions (starting with underscore)"):
+    with it("should only load setup functions (starting with pscheck)"):
         expect(loader.load('spec/fixtures/file_with_helper_functions/')).to(
             contain_exactly_function_called('pscheck_function')
         )


### PR DESCRIPTION
New options allows to test the program with a single file without having
to rename all files in the parent directory to __file.

Loader now tests if the given path is a python file (ends with .py).
If it does, import it and get all pscheck functions from it in the same
way we did with directories.

To avoid duplication, the process of loading the check functions from a
module has been moved to its own function: `_get_checks_from_module`

Tests have been modified to add a new test case for the new
functionality, and changed old descriptions.

~~Problems:~~
- ~~Using `importlib.machinery.SourceFileLoader#load_module` gives us
  access to all the module functions, but not to the functions contained
  in imported modules, so the given file has to be self contained and
  can't import helper functions.~~
