### PR TITLE
Add on_failure decorator

### DIFF
--- a/pysellus/integrations.py
+++ b/pysellus/integrations.py
@@ -1,0 +1,104 @@
+integrations = {}
+integrations_subject = {}
+
+
+def on_failure(*integration_names):
+    """
+    on_failure :: [String] -> (fn -> fn)
+
+    Decorator that maps the given function to the supplied integration names tuple
+
+    Usage:
+    @on_failure('integration')
+    def foo():
+        ...
+
+    Receives a tuple of strings representing an integration (i.e. 'terminal', 'slack'),
+    and returns a decorator function.
+
+    This decorator function takes a function, and, for each string in the original tuple,
+    creates a Subject object (see _get_integration). It then maps it against the
+    given function name, {string: rx.Subject}.
+
+    Finally, returns the original function
+
+    """
+    def decorator_of_setup_function(setup_function):
+        integrations[setup_function.__name__] = [
+            _get_integration(integration_name_)
+            for integration_name_ in integration_names
+        ]
+
+        return setup_function
+
+    return decorator_of_setup_function
+
+
+def _get_integration(integration_name):
+    """
+    _get_integration :: String -> rx.Subject
+
+    Get the Subject object mapped to the given integration name
+
+    If it doesn't exist, create it (see create) and store it in integrations_subject,
+    mapped against the given name {string: rx.Subject}
+
+    """
+    if integration_name not in integrations_subject.keys():
+        integrations_subject[integration_name] = create(integration_name)
+
+    return integrations_subject[integration_name]
+
+
+def register_function_to_subject(subject, *functions):
+    """
+    register_function_to_subject :: rx.Subject -> [fn] -> IO
+
+    Given a subject, and a tuple of functions, subscribe all functions to the subject.
+
+    """
+    for fn in functions:
+        subject.subscribe(fn)
+
+
+def notify_element(test_name, element_payload):
+    _notify_integration(test_name, element_payload)
+
+
+def notify_error(test_name, element_payload):
+    _notify_integration(test_name, element_payload, error=True)
+
+
+def _notify_integration(test_name, message, error=False):
+    """
+    _notify_integration :: String -> Any -> Boolean -> IO
+
+    Given a function name, and a Payload object, send the payload to the appropiate subject.
+
+    Check the function name in integrations and get all mapped subjects, and send the payload to
+    all of them.
+
+    If the error flag is set to true, send the message as an error
+
+    """
+    for integration in integrations[test_name]:
+        if error:
+            integration.on_error(message)
+        else:
+            integration.on_next(message)
+
+
+# TODO: Search for the integration name somewhere and get the functions
+def create(integration_name):
+    """
+    create :: String -> rx.Subject
+
+    Given an integration name, create a new rx.Subject mapped to it
+
+    If a mapped subject already exists, return it.
+
+    In any case, the returned Subject has already been subscribed by all interested functions,
+    so one can send a message to it without fear that the message will be lost
+
+    """
+    pass

--- a/pysellus/registrar.py
+++ b/pysellus/registrar.py
@@ -1,3 +1,7 @@
+import inspect
+
+from pysellus import integrations
+
 stream_to_observers = {}
 
 
@@ -8,10 +12,109 @@ def register(function_list):
 
 
 def expect(stream):
-    def tests_registrar(*testers):
-        if stream in stream_to_observers.keys():
-            stream_to_observers[stream] += list(testers)
-        else:
-            stream_to_observers[stream] = list(testers)
+    """
+    expect :: rx.Observable -> ([(Any -> Boolean)] -> IO)
 
+    Given an observable, return a function that takes a function tuple, and maps them
+
+    Store our caller function name for future use (see _get_expect_caller_function_name)
+
+    """
+    test_name = _get_expect_caller_function_name()
+
+    def tests_registrar(*testers):
+        """
+        tests_registrar :: [(Any -> Boolean)] -> IO
+
+        Given a function tuple, define a wrapper around it, and map it agains the original stream
+        given to expect.
+
+        For each function in the tuple, define a wrapper around it.
+        This wrapper function takes an element (Any) and gives it to the original function.
+
+        This function takes an element, and performs a check on it. If the test returns false,
+        send a message to the appropiate integration (see integrations#notify_{message,error})
+
+        """
+        for tester in testers:
+            def tester_wrapper(element):
+                # NOTE: Note that `watch should implement this as `if tester(element)` instead
+                # NOTE: Also, the 'description' message should change
+                try:
+                    if not tester(element):
+                        integrations.notify_element(test_name, {
+                            'test_name': test_name,
+                            'element': element,
+                            'description': 'Assert error: In {what}, got: {element}'.format(
+                                what=tester.__name__,
+                                element=element
+                            )
+                        })
+                except Exception as e:
+                    # In theory, no exception happening above could crash the application,
+                    # so, again, in _theroy_, this should be safe.
+
+                    # Catch any errors that could happen inside the tester, and send that to
+                    # whoever is interested in the result
+
+                    integrations.notify_error(test_name, {
+                        'test_name': test_name,
+                        'element': element,
+                        'description': 'Exception in {what}: {cause}'.format(
+                            what=tester.__name__,
+                            cause=e
+                        )
+                    })
+            # Save the wrapper, associated with the enclosing setup function
+            register_tester_for_stream(stream, tester_wrapper)
     return tests_registrar
+
+
+def _get_expect_caller_function_name():
+    """
+    _get_expect_caller_function_name :: -> String
+
+    Get the function name of the caller to the `expect` function
+
+    Note: This function should only be called inside the `expect` function. Any other use can not
+    be guaranteed to work
+
+    The stack is a list of frame records. The first entry in it represents the caller,
+    the last entry represents the outermost call on the stack.
+
+    As we want the parent of expect, we should get the fourth element of the stack
+
+    Each frame record  is a tuple of six items: the frame object (0), the filename (1),
+    the line number of the current line (2), the function name (3), a list of lines of context
+    from the source code (4), and the index of the current line within that list (5).
+
+    We want to get the function name, so we will get the [3] element
+
+    Most of this is taken from the docs,
+    see https://docs.python.org/3/library/inspect.html#the-interpreter-stack
+
+    """
+    # Magic. Do not touch.
+    distance_to_setup_function = sum([
+        # at the moment, the call stack looks something like this
+        # ... more frames
+        1,  # call to `pscheck_` function, whose name we want to retrieve
+        1,  # call to `expect`
+        1,  # call to this `_get_expect_caller_function_name`
+    ]) - 1  # stack is 0-indexed
+    return inspect.stack()[distance_to_setup_function][3]
+
+
+def register_tester_for_stream(stream, tester):
+    """
+    register_tester_for_stream :: rx.Observable -> fn -> IO
+
+    Given an Observable, and a tester function, map the Observable to a list of functions.
+
+    If the given stream already has some functions mapped to it, add the given function to the list
+
+    """
+    if stream in stream_to_observers.keys():
+        stream_to_observers[stream].append(tester)
+    else:
+        stream_to_observers[stream] = [tester]

--- a/spec/registrar_spec.py
+++ b/spec/registrar_spec.py
@@ -30,7 +30,9 @@ with description('the registrar module'):
         for function in function_list:
             expect(function).to_not(have_been_called.once)
 
-        expect(registrar.stream_to_observers[stream]).to(equal(function_list))
+        expect(
+            len(registrar.stream_to_observers[stream])
+        ).to(equal(len(function_list)))
 
     with it('should merge n function lists if applied to the same stream'):
         spy = Spy()
@@ -49,5 +51,6 @@ with description('the registrar module'):
         expect_(stream)(*first_function_list)
         expect_(stream)(*second_function_list)
 
-        expect(registrar.stream_to_observers[stream]).to(equal(first_function_list +
-                                                               second_function_list))
+        expect(
+            len(registrar.stream_to_observers[stream])
+        ).to(equal(len(first_function_list + second_function_list)))


### PR DESCRIPTION
In our original spec, the failure message provided to the integration
had to know the test it had failed on. This proved very difficult to
implement with the model we chose on the first place: that is, attach
`@on_failure` to the tester functions.

With this change, we approach integrations differently. Intead of
decorating the tester functions, we decorate the `pscheck_` function
that we transpile from the `@check` DSL functions. This allows us to get
the function name, and allows the user to choose where to notify him/her
depending on the check, not the tester function.

For this to work, we had to modify the original implementation of
expect. Before, it only mapped the given stream to a list of
functions.

``` python
@on_failure('integration_name')
def pscheck_function():
    ...
    expect(foo)(bar)
```

First, `@on_failure` maps the pscheck function to a list of integrations
(implemented internally as Rx Subjects):

Then, `expect` takes a stream (Rx Observable), and returns a registrar
function, that takes a variable number of tester functions. For each of
those, defines a wrapper function and registers that, mapping `pscheck`
functions with a list of tests used inside its body.

The wrapper function takes an element, and passes it to the original
tester. When the tester fails, it will notify all integrations passed to
the `on_failure` decorator, passing the element where it failed, the
`pscheck` function where it happened, and the tester function name. It
will also pass a brief description of the problem.

In addition, if, for whatever reason, an exception is raised inside the
tester, we will catch it and notify the integrations of it, with a
different message that will include the exception message.
