### PR TITLE
Remove interfaces from coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 source = ./pysellus
-omit = ./pysellus/core.py, ./pysellus/__init__.py
+omit = ./pysellus/core.py, ./pysellus/__init__.py, ./pysellus/interfaces.py
 branch = True


### PR DESCRIPTION
Right now, interfaces only contains the AbstractIntegration class, that,
I think, doesn't need to be tested.
