### PR TITLE
Remove pscheck_ limitation from setup functions

### DIFF
--- a/pysellus/integrations.py
+++ b/pysellus/integrations.py
@@ -29,6 +29,7 @@ def on_failure(*integration_names):
 
     """
     def decorator_of_setup_function(setup_function):
+        _mark_as_setup_function(setup_function)
         registered_integrations[setup_function.__name__] = [
             _get_integration(integration_name_)
             for integration_name_ in integration_names
@@ -37,6 +38,10 @@ def on_failure(*integration_names):
         return setup_function
 
     return decorator_of_setup_function
+
+
+def _mark_as_setup_function(function):
+    function.is_setup_function = True
 
 
 def _get_integration(integration_name):

--- a/pysellus/loader.py
+++ b/pysellus/loader.py
@@ -27,9 +27,9 @@ def _get_setup_functions_from_module(module):
     Setup functions are required to start with 'pscheck_'
     """
     functions = []
-    for name in dir(module):
-        value = getattr(module, name)
-        if isfunction(value) and name.startswith('pscheck_'):
+    for entry in dir(module):
+        value = getattr(module, entry)
+        if isfunction(value) and hasattr(value, 'is_setup_function'):
             functions.append(value)
     return functions
 

--- a/spec/fixtures/file_with_helper_functions/file_with_helper_functions.py
+++ b/spec/fixtures/file_with_helper_functions/file_with_helper_functions.py
@@ -6,5 +6,8 @@ def another_helper_function():
     pass
 
 
-def pscheck_function():
+def function():
     pass
+
+function.is_setup_function = True
+

--- a/spec/fixtures/multiple_files/file_1.py
+++ b/spec/fixtures/multiple_files/file_1.py
@@ -1,4 +1,4 @@
-def pscheck_file_1_function_a():
+def file_1_function_a():
     pass
 
 a_number = 7
@@ -6,5 +6,8 @@ a_number = 7
 a_string = 'bleh'
 
 
-def pscheck_file_1_function_b():
+def file_1_function_b():
     pass
+
+file_1_function_a.is_setup_function = True
+file_1_function_b.is_setup_function = True

--- a/spec/fixtures/multiple_files/file_2.py
+++ b/spec/fixtures/multiple_files/file_2.py
@@ -1,10 +1,13 @@
-def pscheck_file_2_function_a():
+def file_2_function_a():
     pass
 
 a_number = 7
 
 
-def pscheck_file_2_function_b():
+def file_2_function_b():
     pass
 
 a_string = 'bleh'
+
+file_2_function_a.is_setup_function = True
+file_2_function_b.is_setup_function = True

--- a/spec/fixtures/multiple_files/file_3.py
+++ b/spec/fixtures/multiple_files/file_3.py
@@ -3,9 +3,13 @@ a_number = 7
 a_string = 'bleh'
 
 
-def pscheck_file_3_function_a():
+def file_3_function_a():
     pass
 
 
-def pscheck_file_3_function_b():
+def file_3_function_b():
     pass
+
+
+file_3_function_a.is_setup_function = True
+file_3_function_b.is_setup_function = True

--- a/spec/fixtures/one_file/to_be_loaded.py
+++ b/spec/fixtures/one_file/to_be_loaded.py
@@ -1,10 +1,13 @@
-def pscheck_a_function():
+def a_function():
     pass
 
 
-def pscheck_another_function():
+def another_function():
     pass
 
 a_number = 7
 
 a_string = 'bleh'
+
+a_function.is_setup_function = True
+another_function.is_setup_function = True

--- a/spec/loader_spec.py
+++ b/spec/loader_spec.py
@@ -7,27 +7,27 @@ from pysellus import loader
 with description('the loader module loads all top-level functions in a directory or file'):
     with it('should load every function when there is only one file'):
         expect(loader.load('spec/fixtures/one_file/')).to(
-            contain_exactly_function_called('pscheck_a_function',
-                                            'pscheck_another_function')
+            contain_exactly_function_called('a_function',
+                                            'another_function')
         )
 
     with it('should load every function of the specified file'):
         expect(loader.load('spec/fixtures/multiple_files/file_1.py')).to(
-            contain_exactly_function_called('pscheck_file_1_function_a',
-                                            'pscheck_file_1_function_b')
+            contain_exactly_function_called('file_1_function_a',
+                                            'file_1_function_b')
         )
 
     with it('should load every function when there is more than one file'):
         expect(loader.load('spec/fixtures/multiple_files/')).to(
-            contain_exactly_function_called('pscheck_file_1_function_a',
-                                            'pscheck_file_1_function_b',
-                                            'pscheck_file_2_function_a',
-                                            'pscheck_file_2_function_b',
-                                            'pscheck_file_3_function_a',
-                                            'pscheck_file_3_function_b')
+            contain_exactly_function_called('file_1_function_a',
+                                            'file_1_function_b',
+                                            'file_2_function_a',
+                                            'file_2_function_b',
+                                            'file_3_function_a',
+                                            'file_3_function_b')
         )
 
-    with it("should only load setup functions (starting with pscheck)"):
+    with it("should only load setup functions"):
         expect(loader.load('spec/fixtures/file_with_helper_functions/')).to(
-            contain_exactly_function_called('pscheck_function')
+            contain_exactly_function_called('function')
         )


### PR DESCRIPTION
Previously, we checked if a function was a setup function by checking
that its name started with `pscheck_`, but this seemed hacky.

Since all setup function must have `on_failure` decorating them, this
decorator will add an `is_setup_function` attribute to the decorated
function.

Now, users can name their setup functions however they want, and on
loader we check if any given function have the `is_setup_function`
attribute set.
