### PR TITLE
Notify integrations of function docstring

### DIFF
--- a/pysellus/integrations.py
+++ b/pysellus/integrations.py
@@ -1,6 +1,15 @@
+from inspect import getdoc
+
 from pysellus import integration_config
 
-""" { test_name: [ registered_integrations ] } """
+"""
+{
+    test_name: {
+        original_name: String,
+        integrations: [ registered_integrations ]
+    }
+}
+"""
 registered_integrations = {}
 
 """ { integration_name: rx.subjects.Subject } """
@@ -30,10 +39,14 @@ def on_failure(*integration_names):
     """
     def decorator_of_setup_function(setup_function):
         _mark_as_setup_function(setup_function)
-        registered_integrations[setup_function.__name__] = [
-            _get_integration(integration_name_)
-            for integration_name_ in integration_names
-        ]
+
+        registered_integrations[setup_function.__name__] = {
+            'original_name': getdoc(setup_function),
+            'integrations': [
+                _get_integration(integration_name_)
+                for integration_name_ in integration_names
+            ]
+        }
 
         return setup_function
 
@@ -101,7 +114,7 @@ def _notify_integrations(test_name, message, error=False):
     If the error flag is set to true, send the message as an error
 
     """
-    for integration in registered_integrations[test_name]:
+    for integration in registered_integrations[test_name]['integrations']:
         if error:
             integration.on_error(message)
         else:

--- a/pysellus/registrar.py
+++ b/pysellus/registrar.py
@@ -57,7 +57,12 @@ def _on_failure_wrapper(test_name, tester, element):
           Also, the description of the payload message should change
 
     """
-    payload_message = _make_message_payload(test_name, tester.__name__, element)
+
+    payload_message = _make_message_payload(
+        integrations.registered_integrations[test_name]['original_name'],
+        tester.__name__,
+        element
+    )
     try:
         if not tester(element):
             integrations.notify_element(test_name, payload_message)

--- a/spec/integrations_spec.py
+++ b/spec/integrations_spec.py
@@ -44,6 +44,7 @@ with description('the integrations module'):
 
             expect(list(integrations.registered_integrations.keys())).to(contain_exactly(decorated_function.__name__))
 
-            for list_of_associated_subjects in integrations.registered_integrations.values():
-                for subject in list_of_associated_subjects:
+            for setup_function in integrations.registered_integrations:
+                for subject in integrations.registered_integrations[setup_function]['integrations']:
                     expect(subject).to(be_a(rx.subjects.Subject))
+


### PR DESCRIPTION
Previously, we were sending the function name to the integration, but
this didn't make much sense as the user never sees this name when
writing tests.

With past changes, we removed the condition of prepending `pscheck_` to
the tester functions, and instead add an attribute to it. Now, we remove
the limitation of having to write long, descriptive function names, and
instead focus on an user-written docstring in the test function.

This paves the way for an easier DSL processing when parsing, we add the
user test description as a docstring, and then send that to the
integration, so the user never knows the intermediate expanded function
name.
