### PR TITLE
Remove `super().__init__()` requirement from Integrations

### DIFF
--- a/pysellus/interfaces.py
+++ b/pysellus/interfaces.py
@@ -4,17 +4,16 @@ from rx.subjects import Subject
 
 
 class AbstractIntegration(metaclass=ABCMeta):
-    def __init__(self):
-        self._subject = Subject()
-
     def get_subject(self):
-        self._subject.subscribe(
+        subject = Subject()
+
+        subject.subscribe(
             self.on_next,
             self.on_error,
             self.on_completed
         )
 
-        return self._subject
+        return subject
 
     @abstractmethod
     def on_next(self, element):

--- a/pysellus/stock_integrations/slack.py
+++ b/pysellus/stock_integrations/slack.py
@@ -11,8 +11,6 @@ class SlackIntegration(AbstractIntegration):
         if self._channel:
             self._payload['channel'] = self._channel
 
-        super().__init__()
-
     def on_next(self, element):
         self._compose_on_next_message(element)
         requests.post(self._url, json=self._payload)


### PR DESCRIPTION
Previously, AbstractIntegration would create a subject on `__init__`, that
would get returned when calling `get_subject`. This made all built-in and
user-defined integrations call the super constructor if they had to
define a custom constructor.

Now, the subject is defined, instantiaded and subscribed on the same
`get_subject` super method. In theory, this method only gets called once,
so this shouldn't cause any problems, but we'll see.
