### PR TITLE
Fix loader documentation

### DIFF
--- a/pysellus/loader.py
+++ b/pysellus/loader.py
@@ -24,7 +24,9 @@ def _get_module_name_from_path(path):
 def _get_setup_functions_from_module(module):
     """
     Gets all setup functions from the given module.
-    Setup functions are required to start with 'pscheck_'
+    All setup functions have the 'is_setup_function' attribute
+
+    See integrations#on_failure
     """
     functions = []
     for entry in dir(module):


### PR DESCRIPTION
Old comment still referenced the 'pscheck_' name limitation.

Updated to point to the correct usage, with the is_setup_function
attribute given to the function with the on_failure decorator.

See 6d5a1350b4bbdd04d1e65418bb37b3d2747cf19a
