### PR TITLE
Support not specifying integration alias

### DIFF
--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -62,8 +62,8 @@ def unpack_integration_configuration_data(integrations_configuration):
         elif _has_only_one_key_and_a_dict_as_value(child):
             integration_name = _get_the_only_key_in(child)
             kwargs_for_integration_constructor = child[integration_name]
-        elif _has_empty_dict(child):
-            integration_name = list(child.keys())[0]
+        elif _has_only_one_key_and_None_as_value(child):
+            integration_name = _get_the_only_key_in(child)
             kwargs_for_integration_constructor = None
         else:
             integration_name = alias
@@ -80,8 +80,8 @@ def _get_the_only_key_in(a_dict):
     return list(a_dict.keys())[0]
 
 
-def _has_empty_dict(child):
-    return list(child.values()) == [None]
+def _has_only_one_key_and_None_as_value(a_dict):
+    return list(a_dict.values()) == [None]
 
 
 def _get_integration_instance(name, kwargs_for_integration_constructor):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -25,8 +25,6 @@ def load_integrations(path):
         instance = _get_integration_instance(configuration)
         loaded_integrations[alias] = instance
 
-    print(loaded_integrations)
-
 
 def _load_integration_config_file(path):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = env/,build/
 max-line-length = 140
 
-; This is to tell pyflakes to ignore mamba's 'it' 
+; F821: this is to tell pyflakes to ignore mamba's 'it' 
 ; and 'description' in spec files, but unfortunately 
 ; there's no way to selectively ignore only certain files.
-ignore = F821
+ignore = F821,E125

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -12,39 +12,71 @@ with description('the integration_config module'):
             integration_config._get_integration_instance = self.integration_config_spy._get_integration_instance
 
         with context('when an integration alias is specified'):
-            with it('requests an integration instance and registers that alias'):
-                kwargs_for_integration_constructor = {
-                    'some_arg': 'some_value',
-                    'another_arg': 35
-                }
-                integrations_configuration = {
-                    'my-alias': {
-                        'an_integration': kwargs_for_integration_constructor
+            with context('and the integration is configured with one or more parameters'):
+                with it('requests an integration instance and registers that alias'):
+                    kwargs_for_integration_constructor = {
+                        'some_arg': 'some_value',
+                        'another_arg': 35
                     }
-                }
+                    integrations_configuration = {
+                        'my-alias': {
+                            'an_integration': kwargs_for_integration_constructor
+                        }
+                    }
 
-                integration_config._load_integrations_from_configuration(integrations_configuration)
+                    integration_config._load_integrations_from_configuration(integrations_configuration)
 
-                expect(self.integration_config_spy._get_integration_instance).to(
-                    have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                )
-                expect(integration_config.loaded_integrations).to(have_key('my-alias'))
+                    expect(self.integration_config_spy._get_integration_instance).to(
+                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                    )
+                    expect(integration_config.loaded_integrations).to(have_key('my-alias'))
+
+            with context('and the integration is configured with no parameters'):
+                with it('requests an integration instance and registers that alias'):
+                    kwargs_for_integration_constructor = None
+                    integrations_configuration = {
+                        'my-alias': {
+                            'an_integration': kwargs_for_integration_constructor
+                        }
+                    }
+
+                    integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                    expect(self.integration_config_spy._get_integration_instance).to(
+                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                    )
+                    expect(integration_config.loaded_integrations).to(have_key('my-alias'))
 
         with context('when an integration alias is not specified'):
-            with it('requests an integration instance and registers the stock name'):
-                kwargs_for_integration_constructor = {
-                    'some_arg': 'some_value'
-                }
-                integrations_configuration = {
-                    'an_integration': kwargs_for_integration_constructor
-                }
+            with context('and the integration is configured with one or more parameters'):
+                with it('requests an integration instance and registers the stock name'):
+                    kwargs_for_integration_constructor = {
+                        'some_arg': 'some_value'
+                    }
+                    integrations_configuration = {
+                        'an_integration': kwargs_for_integration_constructor
+                    }
 
-                integration_config._load_integrations_from_configuration(integrations_configuration)
+                    integration_config._load_integrations_from_configuration(integrations_configuration)
 
-                expect(self.integration_config_spy._get_integration_instance).to(
-                    have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                )
-                expect(integration_config.loaded_integrations).to(have_key('an_integration'))
+                    expect(self.integration_config_spy._get_integration_instance).to(
+                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                    )
+                    expect(integration_config.loaded_integrations).to(have_key('an_integration'))
+
+            with context('and the integration is configured with no parameters'):
+                with it('requests an integration instance and registers the stock name'):
+                    kwargs_for_integration_constructor = None
+                    integrations_configuration = {
+                        'an_integration': kwargs_for_integration_constructor
+                    }
+
+                    integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                    expect(self.integration_config_spy._get_integration_instance).to(
+                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                    )
+                    expect(integration_config.loaded_integrations).to(have_key('an_integration'))
 
         with after.each:
             integration_config._get_integration_instance = self.original_integration_instance_creator

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -1,0 +1,34 @@
+from doublex import Spy
+from expects import expect, have_key
+from doublex_expects import have_been_called_with
+
+from pysellus import integration_config
+
+with description('the integration_config module'):
+    with description('loads integrations from a dict'):
+        with before.each:
+            self.original_integration_instance_provider = integration_config._get_integration_instance
+            self.integration_config_spy = Spy()
+            integration_config._get_integration_instance = self.integration_config_spy._get_integration_instance
+
+        with context('when an integration alias is specified'):
+            with it('requests an integration instance and registers that alias'):
+                configuration_dict_of_an_integration = {
+                    'some_arg': 'some_value',
+                    'another_arg': 35
+                }
+                integrations_configuration = {
+                    'my-alias': {
+                        'an_integration': configuration_dict_of_an_integration
+                    }
+                }
+
+                integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                expect(self.integration_config_spy._get_integration_instance).to(
+                    have_been_called_with('an_integration', configuration_dict_of_an_integration).once
+                )
+                expect(integration_config.loaded_integrations).to(have_key('my-alias'))
+
+        with after.each:
+            integration_config._get_integration_instance = self.original_integration_instance_provider

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -7,28 +7,44 @@ from pysellus import integration_config
 with description('the integration_config module'):
     with description('loads integrations from a dict'):
         with before.each:
-            self.original_integration_instance_provider = integration_config._get_integration_instance
+            self.original_integration_instance_creator = integration_config._get_integration_instance
             self.integration_config_spy = Spy()
             integration_config._get_integration_instance = self.integration_config_spy._get_integration_instance
 
         with context('when an integration alias is specified'):
             with it('requests an integration instance and registers that alias'):
-                configuration_dict_of_an_integration = {
+                kwargs_for_integration_constructor = {
                     'some_arg': 'some_value',
                     'another_arg': 35
                 }
                 integrations_configuration = {
                     'my-alias': {
-                        'an_integration': configuration_dict_of_an_integration
+                        'an_integration': kwargs_for_integration_constructor
                     }
                 }
 
                 integration_config._load_integrations_from_configuration(integrations_configuration)
 
                 expect(self.integration_config_spy._get_integration_instance).to(
-                    have_been_called_with('an_integration', configuration_dict_of_an_integration).once
+                    have_been_called_with('an_integration', kwargs_for_integration_constructor).once
                 )
                 expect(integration_config.loaded_integrations).to(have_key('my-alias'))
 
+        with context('when an integration alias is not specified'):
+            with it('requests an integration instance and registers the stock name'):
+                kwargs_for_integration_constructor = {
+                    'some_arg': 'some_value'
+                }
+                integrations_configuration = {
+                    'an_integration': kwargs_for_integration_constructor
+                }
+
+                integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                expect(self.integration_config_spy._get_integration_instance).to(
+                    have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                )
+                expect(integration_config.loaded_integrations).to(have_key('an_integration'))
+
         with after.each:
-            integration_config._get_integration_instance = self.original_integration_instance_provider
+            integration_config._get_integration_instance = self.original_integration_instance_creator


### PR DESCRIPTION
Notice that this code will fail to understand an integration declared with an
alias and which needs to be configured with only one argument whose value is a
dictionary:

```
notify:
    my-alias:
        the-integration-name:
            the-only-argument:
                a-dict-key: 'a dict value'
                another-dict-key: 'another dict value'
                yet-another-dict-key: 'yet another dict value'
```

I believe this is so far an unlikely scenario, because if the value needs to be
a dictionary, you might as well allow it to be inlined at the argument level,
like so:

```
notify:
    my-alias:
        the-integration-name:
            a-dict-key: 'a dict value'
            another-dict-key: 'another dict value'
            yet-another-dict-key: 'yet another dict value'
```

and supporting it would make the problem far harder to solve without changing
the integration declaration schema.
