### PR TITLE
Support for custom integrations

### DIFF
--- a/pysellus/core.py
+++ b/pysellus/core.py
@@ -25,7 +25,7 @@ def main():
 
     threader.launch_threads(
         threader.build_threads(
-            registrar.register(loader.load(user_input))
+            registrar.register(loader.load_test_files(user_input))
         )
     )
 

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -4,7 +4,7 @@ import inspect
 import yaml
 
 from pysellus.loader import load_modules
-from pysellus.stock_integrations import integration_classes
+from pysellus.stock_integrations import stock_integration_classes
 
 
 CONFIGURATION_FILE_NAME = '.ps_integrations.yml'
@@ -51,7 +51,7 @@ def _load_config_file(path):
 
 def _load_custom_integrations(custom_configuration):
     for alias, configuration in custom_configuration.items():
-        if alias in integration_classes.keys():
+        if alias in stock_integration_classes.keys():
             exit(
                 "Conflicting integration name '{}'. Integration names must be unique\nAborting..."
                 .format(alias)
@@ -75,7 +75,7 @@ def _load_custom_integrations(custom_configuration):
                 )
             )
 
-        integration_classes[alias] = classobject
+        stock_integration_classes[alias] = classobject
 
 
 def _get_matching_classobject_from_path(class_name, path):
@@ -135,7 +135,7 @@ def _get_integration_instance(name, kwargs_for_integration_constructor):
     parameter dictionary.
     """
     try:
-        integration_class = integration_classes[name]
+        integration_class = stock_integration_classes[name]
         if kwargs_for_integration_constructor is None:
             return integration_class()
         else:

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -44,22 +44,6 @@ def _load_config_file(path):
             exit("Error while reading {}: file seems to be empty".format(CONFIGURATION_FILE_NAME))
 
 
-def _load_defined_integrations(configuration):
-    """
-    _load_defined_integrations :: {} -> IO
-
-    Given an integration configuration dict, get their constructors and import them,
-    then add them to the integrations#loaded_integrations dict.
-
-    Fails if the constructor section is missing.
-    """
-    try:
-        integration_configuration = configuration['notify']
-        _load_integrations_from_configuration(integration_configuration)
-    except KeyError:
-        exit("Malformed configuration file: missing 'notify' section")
-
-
 def _load_custom_integrations(configuration):
     """
     _load_custom_integrations :: {} -> IO
@@ -128,6 +112,22 @@ def _get_matching_classobject_from_path(class_name, path):
     for name, classobject in module_members:
         if name == class_name:
             return classobject
+
+
+def _load_defined_integrations(configuration):
+    """
+    _load_defined_integrations :: {} -> IO
+
+    Given an integration configuration dict, get their constructors and import them,
+    then add them to the integrations#loaded_integrations dict.
+
+    Fails if the constructor section is missing.
+    """
+    try:
+        integration_configuration = configuration['notify']
+        _load_integrations_from_configuration(integration_configuration)
+    except KeyError:
+        exit("Malformed configuration file: missing 'notify' section")
 
 
 def _load_integrations_from_configuration(integrations_configuration):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -3,7 +3,7 @@ import inspect
 
 import yaml
 
-from pysellus.loader import load_modules
+from pysellus import loader
 from pysellus.integrations import loaded_integrations, integration_classes
 
 CONFIGURATION_FILE_NAME = '.ps_integrations.yml'
@@ -77,8 +77,11 @@ def _load_custom_integrations_classes(custom_configuration):
                 .format(alias)
             )
 
-        integration_name = configuration['name']
-        integration_path = configuration['path']
+        integration_name = configuration.pop('name', None)
+        integration_path = configuration.pop('path', None)
+
+        if integration_classes is None or integration_path is None:
+            exit("Malformed integration '{}': missing class name and/or module path".format(alias))
 
         classobject = _get_matching_classobject_from_path(
             integration_name,
@@ -107,7 +110,7 @@ def _get_matching_classobject_from_path(class_name, path):
 
     If no match is found, return None.
     """
-    integration_module = load_modules(path)[0]
+    integration_module = loader.load_modules(path)[0]
     module_members = inspect.getmembers(integration_module, inspect.isclass)
     for name, classobject in module_members:
         if name == class_name:

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -80,7 +80,7 @@ def _load_custom_integrations_classes(custom_configuration):
         integration_name = configuration.pop('name', None)
         integration_path = configuration.pop('path', None)
 
-        if integration_classes is None or integration_path is None:
+        if not all((integration_name, integration_path)):
             exit("Malformed integration '{}': missing class name and/or module path".format(alias))
 
         classobject = _get_matching_classobject_from_path(

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -53,11 +53,11 @@ def _load_custom_integrations(configuration):
 
     If the definition is missing, pass.
     """
-    try:
-        custom_integrations_configuration = configuration['custom_integrations']
-        _load_custom_integrations_classes(custom_integrations_configuration)
-    except KeyError:
-        pass  # it's ok for the user to not define custom integrations
+    if 'custom_integrations' not in configuration:
+        return
+
+    custom_integrations_configuration = configuration['custom_integrations']
+    _load_custom_integrations_classes(custom_integrations_configuration)
 
 
 def _load_custom_integrations_classes(custom_configuration):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -47,11 +47,11 @@ def _load_config_file(path):
 
 def _load_integrations_from_configuration(integrations_configuration):
     for alias, integration_name, kwargs_for_integration_constructor \
-        in unpack_integration_configuration_data(integrations_configuration):
-            loaded_integrations[alias] = _get_integration_instance(
-                integration_name,
-                kwargs_for_integration_constructor
-            )
+            in unpack_integration_configuration_data(integrations_configuration):
+        loaded_integrations[alias] = _get_integration_instance(
+            integration_name,
+            kwargs_for_integration_constructor
+        )
 
 
 def unpack_integration_configuration_data(integrations_configuration):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -141,5 +141,4 @@ def _get_integration_instance(name, kwargs_for_integration_constructor):
         else:
             return integration_class(**kwargs_for_integration_constructor)
     except KeyError:
-        print("The '{}' integration does not exist\nAborting...".format(name))
-        exit(1)
+        exit("On integration '{}': definition missing\nAborting...".format(name))

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -16,9 +16,6 @@ def load_integrations(path):
     Given a path, find the config file at it and load it.
     """
     configuration = _load_config_file(path)
-    if configuration is None:
-        exit("Error while reading {}: file seems to be empty".format(CONFIGURATION_FILE_NAME))
-
     _load_custom_integrations(configuration)
     _load_defined_integrations(configuration)
 
@@ -42,7 +39,9 @@ def _load_config_file(path):
         raise FileNotFoundError
 
     with open(config_path, 'r') as config_file:
-        return yaml.load(config_file)
+        config = yaml.load(config_file)
+        return config if config else \
+            exit("Error while reading {}: file seems to be empty".format(CONFIGURATION_FILE_NAME))
 
 
 def _load_defined_integrations(configuration):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -51,6 +51,12 @@ def _load_config_file(path):
 
 def _load_custom_integrations(custom_configuration):
     for alias, configuration in custom_configuration.items():
+        if alias in integration_classes.keys():
+            exit(
+                "Conflicting integration name '{}'. Integration names must be unique\nAborting..."
+                .format(alias)
+            )
+
         integration_name = configuration['name']
         integration_path = configuration['path']
 

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -140,10 +140,13 @@ def _get_matching_classobject_from_path(class_name, path):
     If no match is found, return None.
     """
     integration_module = loader.load_modules(path)[0]
-    module_members = inspect.getmembers(integration_module, inspect.isclass)
-    for name, classobject in module_members:
+    for name, classobject in _get_classes_in_module(integration_module):
         if name == class_name:
             return classobject
+
+
+def _get_classes_in_module(module):
+    return inspect.getmembers(module, inspect.isclass)
 
 
 def _load_defined_integrations(configuration):

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -100,14 +100,14 @@ def _get_matching_classobject_from_path(class_name, path):
 
 def _load_integrations_from_configuration(integrations_configuration):
     for alias, integration_name, kwargs_for_integration_constructor \
-            in unpack_integration_configuration_data(integrations_configuration):
+            in _unpack_integration_configuration_data(integrations_configuration):
         loaded_integrations[alias] = _get_integration_instance(
             integration_name,
             kwargs_for_integration_constructor
         )
 
 
-def unpack_integration_configuration_data(integrations_configuration):
+def _unpack_integration_configuration_data(integrations_configuration):
     for alias, child in integrations_configuration.items():
         if child is None:
             integration_name = alias

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -37,9 +37,11 @@ def _load_config_file(path):
         try:
             configuration = _load_configuration_from_contents_of_config_file(config_file)
         except EmptyConfigurationFileError as error:
-            exit("Error while reading {path}: {reason}".format(
-                path=path_to_configuration_file,
-                reason=error.message
+            exit(
+                "Error while reading {path}: {reason}"
+                .format(
+                    path=path_to_configuration_file,
+                    reason=error.message
                 )
             )
 
@@ -51,18 +53,20 @@ def _get_path_to_configuration_file(path):
     path_to_configuration_file = os.path.join(
         directory_containing_configuration_file,
         CONFIGURATION_FILE_NAME
-        )
+    )
 
     if not os.path.exists(path_to_configuration_file):
         raise FileNotFoundError
 
     return path_to_configuration_file
 
+
 def _get_parent_directory_of_path(path):
     if os.path.isdir(path):
         return path
 
     return os.path.dirname(path)
+
 
 def _load_configuration_from_contents_of_config_file(contents_of_config_file):
     loaded_configuration = yaml.load(contents_of_config_file)

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -4,13 +4,9 @@ import inspect
 import yaml
 
 from pysellus.loader import load_modules
-from pysellus.stock_integrations import stock_integration_classes
-
+from pysellus.integrations import loaded_integrations, integration_classes
 
 CONFIGURATION_FILE_NAME = '.ps_integrations.yml'
-
-# {integration_alias: integration_instance}
-loaded_integrations = {}
 
 
 def load_integrations(path):
@@ -67,7 +63,7 @@ def _load_custom_integrations(configuration):
 
 def _load_custom_integrations_classes(custom_configuration):
     for alias, configuration in custom_configuration.items():
-        if alias in stock_integration_classes.keys():
+        if alias in integration_classes.keys():
             exit(
                 "Conflicting integration name '{}'. Integration names must be unique\nAborting..."
                 .format(alias)
@@ -91,7 +87,7 @@ def _load_custom_integrations_classes(custom_configuration):
                 )
             )
 
-        stock_integration_classes[alias] = classobject
+        integration_classes[alias] = classobject
 
 
 def _get_matching_classobject_from_path(class_name, path):
@@ -151,7 +147,7 @@ def _get_integration_instance(name, kwargs_for_integration_constructor):
     parameter dictionary.
     """
     try:
-        integration_class = stock_integration_classes[name]
+        integration_class = integration_classes[name]
         if kwargs_for_integration_constructor is None:
             return integration_class()
         else:

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -6,6 +6,7 @@ import yaml
 from pysellus import loader
 from pysellus.integrations import loaded_integrations, integration_classes
 
+
 CONFIGURATION_FILE_NAME = '.ps_integrations.yml'
 
 
@@ -30,13 +31,7 @@ def _load_config_file(path):
 
     If no configuration file is found, raise a FileNotFound exception.
     """
-    if os.path.isfile(path):
-        path = path.rsplit('/', 1)[0]
-
-    path_to_configuration_file = path + '/' + CONFIGURATION_FILE_NAME
-
-    if not os.path.exists(path_to_configuration_file):
-        raise FileNotFoundError
+    path_to_configuration_file = _get_path_to_configuration_file(path)
 
     with open(path_to_configuration_file, 'r') as config_file:
         try:
@@ -50,6 +45,24 @@ def _load_config_file(path):
 
         return configuration
 
+
+def _get_path_to_configuration_file(path):
+    directory_containing_configuration_file = _get_parent_directory_of_path(path)
+    path_to_configuration_file = os.path.join(
+        directory_containing_configuration_file,
+        CONFIGURATION_FILE_NAME
+        )
+
+    if not os.path.exists(path_to_configuration_file):
+        raise FileNotFoundError
+
+    return path_to_configuration_file
+
+def _get_parent_directory_of_path(path):
+    if os.path.isdir(path):
+        return path
+
+    return os.path.dirname(path)
 
 def _load_configuration_from_contents_of_config_file(contents_of_config_file):
     loaded_configuration = yaml.load(contents_of_config_file)

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -45,6 +45,14 @@ def _load_config_file(path):
 
 
 def _load_defined_integrations(configuration):
+    """
+    _load_defined_integrations :: {} -> IO
+
+    Given an integration configuration dict, get their constructors and import them,
+    then add them to the integrations#loaded_integrations dict.
+
+    Fails if the constructor section is missing.
+    """
     try:
         integration_configuration = configuration['notify']
         _load_integrations_from_configuration(integration_configuration)
@@ -53,6 +61,14 @@ def _load_defined_integrations(configuration):
 
 
 def _load_custom_integrations(configuration):
+    """
+    _load_custom_integrations :: {} -> IO
+
+    Given an integration configuration dict, get their definitions and import them,
+    then add them to the integrations#loaded_integrations dict.
+
+    If the definition is missing, pass.
+    """
     try:
         custom_integrations_configuration = configuration['custom_integrations']
         _load_custom_integrations_classes(custom_integrations_configuration)
@@ -61,6 +77,15 @@ def _load_custom_integrations(configuration):
 
 
 def _load_custom_integrations_classes(custom_configuration):
+    """
+    _load_custom_integrations_classes :: {} -> IO
+
+    Given a map of configuration definitions, find the integration module, import it,
+    and then load the appropiate class object into the integration_classes dict.
+
+    Fails if it can't find the class object inside the module, or if the integration
+    name is a duplicate.
+    """
     for alias, configuration in custom_configuration.items():
         if alias in integration_classes.keys():
             exit(
@@ -90,6 +115,14 @@ def _load_custom_integrations_classes(custom_configuration):
 
 
 def _get_matching_classobject_from_path(class_name, path):
+    """
+    _get_matching_classobject_from_path :: String -> String -> python.ClassObject | None
+
+    Given a class name, and a module path, search for the given class inside it and return the
+    first match.
+
+    If no match is found, return None.
+    """
     integration_module = load_modules(path)[0]
     module_members = inspect.getmembers(integration_module, inspect.isclass)
     for name, classobject in module_members:
@@ -98,6 +131,13 @@ def _get_matching_classobject_from_path(class_name, path):
 
 
 def _load_integrations_from_configuration(integrations_configuration):
+    """
+    _load_integrations_from_configuration :: {} -> IO
+
+    Given a map of integration constructors, gather the attributes and build an instance
+    of the integration. Then map their aliases with their instances inside the
+    loaded_integrations dict
+    """
     for alias, integration_name, kwargs_for_integration_constructor \
             in _unpack_integration_configuration_data(integrations_configuration):
         loaded_integrations[alias] = _get_integration_instance(
@@ -107,6 +147,14 @@ def _load_integrations_from_configuration(integrations_configuration):
 
 
 def _unpack_integration_configuration_data(integrations_configuration):
+    """
+    _unpack_integration_configuration_data :: {} -> (String, String, {} | None)
+
+    Given a map of integration constructors, gather the attributes into an alias, the integration
+    name and a map of constructor parameters.
+
+    Yields a tuple on every call.
+    """
     for alias, child in integrations_configuration.items():
         if child is None:
             integration_name = alias

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -106,24 +106,24 @@ def _load_custom_integrations_classes(custom_configuration):
                 .format(alias)
             )
 
-        integration_name = configuration.pop('name', None)
-        integration_path = configuration.pop('path', None)
-
-        if not all((integration_name, integration_path)):
+        try:
+            integration_class_name = configuration['name']
+            path_to_integration_module = configuration['path']
+        except KeyError:
             exit("Malformed integration '{}': missing class name and/or module path".format(alias))
 
         classobject = _get_matching_classobject_from_path(
-            integration_name,
-            integration_path
+            integration_class_name,
+            path_to_integration_module
         )
 
         if classobject is None:
             exit(
-                "Malformed custom integration '{alias}:\n\t'{klass}' class not found in {module}"
+                "Malformed custom integration '{alias}:\n\t'{klass}' class not found in {path_to_integration_module}"
                 .format(
                     alias=alias,
-                    klass=integration_name,
-                    module=integration_path
+                    klass=integration_class_name,
+                    path_to_integration_module=path_to_integration_module
                 )
             )
 

--- a/pysellus/integration_config.py
+++ b/pysellus/integration_config.py
@@ -35,7 +35,7 @@ def _load_config_file(path):
 
     with open(path_to_configuration_file, 'r') as config_file:
         try:
-            configuration = _load_configuration_from_contents_of_config_file(config_file)
+            configuration = _load_configuration_from_config_file(config_file)
         except EmptyConfigurationFileError as error:
             exit(
                 "Error while reading {path}: {reason}"
@@ -68,8 +68,8 @@ def _get_parent_directory_of_path(path):
     return os.path.dirname(path)
 
 
-def _load_configuration_from_contents_of_config_file(contents_of_config_file):
-    loaded_configuration = yaml.load(contents_of_config_file)
+def _load_configuration_from_config_file(config_file):
+    loaded_configuration = yaml.load(config_file)
 
     if loaded_configuration is None:
         raise EmptyConfigurationFileError()

--- a/pysellus/integrations.py
+++ b/pysellus/integrations.py
@@ -1,6 +1,14 @@
 from inspect import getdoc
 
-from pysellus import integration_config
+from pysellus.stock_integrations import stock_integration_classes
+
+# integration_name -> integration_class_object
+# maps integration names to its object classes (inside modules)
+integration_classes = stock_integration_classes
+
+# integration_alias -> integration_instance
+# maps integration aliases to class instances
+loaded_integrations = {}
 
 """
 {
@@ -91,12 +99,12 @@ def _create(integration_name):
 
     """
     try:
-        integration_instance = integration_config.loaded_integrations[integration_name]
+        integration_instance = loaded_integrations[integration_name]
         return integration_instance.get_subject()
     except KeyError as e:
-        print("The integration {} is used, but it's not declared,".format(e))
-        print("check that all integrations used are correctly declared in the configuration file")
-        exit(1)
+        exit("The integration {} is used, but it's not declared,\n"
+             "check that all integrations used are correctly declared in the configuration file"
+             .format(e))
 
 
 def notify_element(test_name, element_payload):

--- a/pysellus/integrations.py
+++ b/pysellus/integrations.py
@@ -100,11 +100,12 @@ def _create(integration_name):
     """
     try:
         integration_instance = loaded_integrations[integration_name]
-        return integration_instance.get_subject()
     except KeyError as e:
         exit("The integration {} is used, but it's not declared,\n"
              "check that all integrations used are correctly declared in the configuration file"
              .format(e))
+
+    return integration_instance.get_subject()
 
 
 def notify_element(test_name, element_payload):

--- a/pysellus/loader.py
+++ b/pysellus/loader.py
@@ -4,17 +4,39 @@ from inspect import isfunction
 from importlib import import_module
 
 
-def load(path):
-    if _is_python_file(path):
-        sys.path.insert(0, os.path.dirname(path))
-        module = import_module(_get_module_name_from_path(path))
-        return _get_setup_functions_from_module(module)
+def load_test_files(path):
+    """
+    load_test_files :: String -> [(a -> b)]
+
+    Given a filesystem path, import all modules under that path, then import all setup_functions
+    inside those modules.
+
+    See load_modules, _get_setup_functions_from_module
+    """
+    modules = load_modules(path)
 
     functions = []
-    for module in _get_modules(path):
+    for module in modules:
         functions += _get_setup_functions_from_module(module)
 
     return functions
+
+
+def load_modules(path):
+    """
+    load_modules :: String -> [python.Module]
+
+    Given a filesystem path, import all modules under that path.
+
+    If the path is a file, import that file. If it's a directory, import all python files inside
+    that folder, in a non-recursive manner.
+    """
+    if _is_python_file(path):
+        sys.path.insert(0, os.path.dirname(path))
+        module = import_module(_get_module_name_from_path(path))
+        return [module]
+
+    return _get_modules(path)
 
 
 def _get_module_name_from_path(path):

--- a/pysellus/stock_integrations/__init__.py
+++ b/pysellus/stock_integrations/__init__.py
@@ -1,6 +1,6 @@
 from pysellus.stock_integrations import terminal, slack, trello
 
-integration_classes = {
+stock_integration_classes = {
     'terminal': terminal.TerminalIntegration,
     'slack': slack.SlackIntegration,
     'trello': trello.TrelloIntegration

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -2,6 +2,7 @@ from doublex import Spy
 from expects import expect, have_key
 from doublex_expects import have_been_called_with
 
+from pysellus import integrations
 from pysellus import integration_config
 
 with description('the integration_config module'):
@@ -29,7 +30,7 @@ with description('the integration_config module'):
                     expect(self.integration_config_spy._get_integration_instance).to(
                         have_been_called_with('an_integration', kwargs_for_integration_constructor).once
                     )
-                    expect(integration_config.loaded_integrations).to(have_key('my-alias'))
+                    expect(integrations.loaded_integrations).to(have_key('my-alias'))
 
             with context('and the integration is configured with no parameters'):
                 with it('requests an integration instance and registers that alias'):
@@ -45,7 +46,7 @@ with description('the integration_config module'):
                     expect(self.integration_config_spy._get_integration_instance).to(
                         have_been_called_with('an_integration', kwargs_for_integration_constructor).once
                     )
-                    expect(integration_config.loaded_integrations).to(have_key('my-alias'))
+                    expect(integrations.loaded_integrations).to(have_key('my-alias'))
 
         with context('when an integration alias is not specified'):
             with context('and the integration is configured with one or more parameters'):
@@ -62,7 +63,7 @@ with description('the integration_config module'):
                     expect(self.integration_config_spy._get_integration_instance).to(
                         have_been_called_with('an_integration', kwargs_for_integration_constructor).once
                     )
-                    expect(integration_config.loaded_integrations).to(have_key('an_integration'))
+                    expect(integrations.loaded_integrations).to(have_key('an_integration'))
 
             with context('and the integration is configured with no parameters'):
                 with it('requests an integration instance and registers the stock name'):
@@ -76,7 +77,7 @@ with description('the integration_config module'):
                     expect(self.integration_config_spy._get_integration_instance).to(
                         have_been_called_with('an_integration', kwargs_for_integration_constructor).once
                     )
-                    expect(integration_config.loaded_integrations).to(have_key('an_integration'))
+                    expect(integrations.loaded_integrations).to(have_key('an_integration'))
 
         with after.each:
             integration_config._get_integration_instance = self.original_integration_instance_creator

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -28,16 +28,10 @@ with description('the integration_config module'):
 
                     os.path.isfile = isfile
 
-        # PermissonError: [Errno 1] Operation not permitted
-        with it('exits the program if the file is empty'):
-            path = '/tmp/ps' + integration_config.CONFIGURATION_FILE_NAME
-            os.mknod(path)
-
-            expect(lambda: integration_config._load_config_file(path)).to(
-                raise_error(SystemExit)
-            )
-
-            os.remove(path)
+            with it('raises an exception if the config file is empty'):
+                expect(lambda: integration_config._load_configuration_from_contents_of_config_file('')).to(
+                    raise_error(integration_config.EmptyConfigurationFileError)
+                )
 
     with description('loads integrations from a dict'):
         with context('which has a definition section'):

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -11,19 +11,22 @@ from pysellus import integration_config
 
 with description('the integration_config module'):
     with description('loads integrations from a config file'):
-        with it('raises FileNotFoundError if the file doesn\'t exist'):
-            expect(lambda: integration_config._load_config_file('/bogus/path')).to(
-                raise_error(FileNotFoundError)
-            )
+            with context('when given a path to a directory'):
+                with it('raises FileNotFoundError if the config file doesn\'t exist in that directory'):
+                    expect(lambda: integration_config._load_config_file('/bogus/path')).to(
+                        raise_error(FileNotFoundError)
+                    )
 
-            isfile = os.path.isfile
-            os.path.isfile = lambda pth: True
+            with context('when given a path to a file'):
+                with it('raises FileNotFoundError if the config file doesn\' exist in the parent folder of the given path'):
+                    isfile = os.path.isfile
+                    os.path.isfile = lambda pth: True
 
-            expect(lambda: integration_config._load_config_file('/bogus/path/file.py')).to(
-                raise_error(FileNotFoundError)
-            )
+                    expect(lambda: integration_config._load_config_file('/bogus/path/file.py')).to(
+                        raise_error(FileNotFoundError)
+                    )
 
-            os.path.isfile = isfile
+                    os.path.isfile = isfile
 
         # PermissonError: [Errno 1] Operation not permitted
         with it('exits the program if the file is empty'):

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -1,5 +1,4 @@
 import os
-import inspect
 import tempfile
 import shutil
 
@@ -43,7 +42,6 @@ with description('the integration_config module'):
                 with after.each:
                     shutil.rmtree(self.path_to_directory_without_config_file)
 
-
             with it('raises an exception if the config file is empty'):
                 expect(lambda: integration_config._load_configuration_from_contents_of_config_file('')).to(
                     raise_error(integration_config.EmptyConfigurationFileError)
@@ -83,20 +81,19 @@ with description('the integration_config module'):
 
                         config_dict = {'some_alias': {
                             'name': an_integration_class_name,
-                            'path':a_path_to_an_integration_module
+                            'path': a_path_to_an_integration_module
                         }}
 
                         an_integration_class_object = Spy()
 
                         loader.load_modules = lambda path: ['sample_returned_module']
-                        integration_config._get_classes_in_module = lambda module: [(an_integration_class_name, an_integration_class_object)]
-
+                        integration_config._get_classes_in_module = \
+                            lambda module: [(an_integration_class_name, an_integration_class_object)]
 
                         expect(integration_config._get_matching_classobject_from_path(
                             an_integration_class_name,
                             a_path_to_an_integration_module)
                         ).to(be(an_integration_class_object))
-
 
                         loader.load_modules = load_modules
                         integration_config._get_classes_in_module = original_class_finder
@@ -110,17 +107,16 @@ with description('the integration_config module'):
 
                         config_dict = {'some_alias': {
                             'name': an_integration_class_name,
-                            'path':a_path_to_an_integration_module
+                            'path': a_path_to_an_integration_module
                         }}
 
                         an_integration_class_object = Spy()
 
                         loader.load_modules = lambda path: ['sample_returned_module']
-                        integration_config._get_classes_in_module = lambda module: [(an_integration_class_name, an_integration_class_object)]
-
+                        integration_config._get_classes_in_module = \
+                            lambda module: [(an_integration_class_name, an_integration_class_object)]
 
                         integration_config._load_custom_integrations_classes(config_dict)
-
 
                         expect(integrations.integration_classes).to(have_key('some_alias'))
                         expect(integration_config.integration_classes['some_alias']).to(be(an_integration_class_object))

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -1,83 +1,112 @@
+import os
+
 from doublex import Spy
-from expects import expect, have_key
+from expects import expect, have_key, raise_error, be
 from doublex_expects import have_been_called_with
 
 from pysellus import integrations
 from pysellus import integration_config
 
 with description('the integration_config module'):
+    with description('loads integrations from a config file'):
+        with it('raises FileNotFoundError if the file doesn\'t exist'):
+            expect(lambda: integration_config._load_config_file('/bogus/path')).to(
+                raise_error(FileNotFoundError)
+            )
+
+        # PermissonError: [Errno 1] Operation not permitted
+        with _it('exits the program if the file is empty'):
+            path = '/tmp/ps' + integration_config.CONFIGURATION_FILE_NAME
+            os.mknod(path)
+
+            expect(lambda: integration_config._load_config_file(path)).to(
+                raise_error(SystemExit)
+            )
+
+            os.remove(path)
+
     with description('loads integrations from a dict'):
-        with before.each:
-            self.original_integration_instance_creator = integration_config._get_integration_instance
-            self.integration_config_spy = Spy()
-            integration_config._get_integration_instance = self.integration_config_spy._get_integration_instance
+        with context('which has a definition section'):
+            with it('returns None if it is missing'):
+                expect(integration_config._load_custom_integrations({})).to(be(None))
 
-        with context('when an integration alias is specified'):
-            with context('and the integration is configured with one or more parameters'):
-                with it('requests an integration instance and registers that alias'):
-                    kwargs_for_integration_constructor = {
-                        'some_arg': 'some_value',
-                        'another_arg': 35
-                    }
-                    integrations_configuration = {
-                        'my-alias': {
+        with context('and a notify section'):
+            with before.each:
+                self.original_integration_instance_creator = integration_config._get_integration_instance
+                self.integration_config_spy = Spy()
+                integration_config._get_integration_instance = self.integration_config_spy._get_integration_instance
+
+            with it('aborts the program if it is missing'):
+                expect(lambda: integration_config._load_defined_integrations({})).to(
+                    raise_error(SystemExit)
+                )
+
+            with context('when an integration alias is specified'):
+                with context('and the integration is configured with one or more parameters'):
+                    with it('requests an integration instance and registers that alias'):
+                        kwargs_for_integration_constructor = {
+                            'some_arg': 'some_value',
+                            'another_arg': 35
+                        }
+                        integrations_configuration = {
+                            'my-alias': {
+                                'an_integration': kwargs_for_integration_constructor
+                            }
+                        }
+
+                        integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                        expect(self.integration_config_spy._get_integration_instance).to(
+                            have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                        )
+                        expect(integrations.loaded_integrations).to(have_key('my-alias'))
+
+                with context('and the integration is configured with no parameters'):
+                    with it('requests an integration instance and registers that alias'):
+                        kwargs_for_integration_constructor = None
+                        integrations_configuration = {
+                            'my-alias': {
+                                'an_integration': kwargs_for_integration_constructor
+                            }
+                        }
+
+                        integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                        expect(self.integration_config_spy._get_integration_instance).to(
+                            have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                        )
+                        expect(integrations.loaded_integrations).to(have_key('my-alias'))
+
+                with context('when an integration alias is not specified'):
+                    with context('and the integration is configured with one or more parameters'):
+                        with it('requests an integration instance and registers the stock name'):
+                            kwargs_for_integration_constructor = {
+                                'some_arg': 'some_value'
+                            }
+                            integrations_configuration = {
+                                'an_integration': kwargs_for_integration_constructor
+                            }
+
+                            integration_config._load_integrations_from_configuration(integrations_configuration)
+
+                            expect(self.integration_config_spy._get_integration_instance).to(
+                                have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                            )
+                            expect(integrations.loaded_integrations).to(have_key('an_integration'))
+
+                with context('and the integration is configured with no parameters'):
+                    with it('requests an integration instance and registers the stock name'):
+                        kwargs_for_integration_constructor = None
+                        integrations_configuration = {
                             'an_integration': kwargs_for_integration_constructor
                         }
-                    }
 
-                    integration_config._load_integrations_from_configuration(integrations_configuration)
+                        integration_config._load_integrations_from_configuration(integrations_configuration)
 
-                    expect(self.integration_config_spy._get_integration_instance).to(
-                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                    )
-                    expect(integrations.loaded_integrations).to(have_key('my-alias'))
+                        expect(self.integration_config_spy._get_integration_instance).to(
+                            have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                        )
+                        expect(integrations.loaded_integrations).to(have_key('an_integration'))
 
-            with context('and the integration is configured with no parameters'):
-                with it('requests an integration instance and registers that alias'):
-                    kwargs_for_integration_constructor = None
-                    integrations_configuration = {
-                        'my-alias': {
-                            'an_integration': kwargs_for_integration_constructor
-                        }
-                    }
-
-                    integration_config._load_integrations_from_configuration(integrations_configuration)
-
-                    expect(self.integration_config_spy._get_integration_instance).to(
-                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                    )
-                    expect(integrations.loaded_integrations).to(have_key('my-alias'))
-
-        with context('when an integration alias is not specified'):
-            with context('and the integration is configured with one or more parameters'):
-                with it('requests an integration instance and registers the stock name'):
-                    kwargs_for_integration_constructor = {
-                        'some_arg': 'some_value'
-                    }
-                    integrations_configuration = {
-                        'an_integration': kwargs_for_integration_constructor
-                    }
-
-                    integration_config._load_integrations_from_configuration(integrations_configuration)
-
-                    expect(self.integration_config_spy._get_integration_instance).to(
-                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                    )
-                    expect(integrations.loaded_integrations).to(have_key('an_integration'))
-
-            with context('and the integration is configured with no parameters'):
-                with it('requests an integration instance and registers the stock name'):
-                    kwargs_for_integration_constructor = None
-                    integrations_configuration = {
-                        'an_integration': kwargs_for_integration_constructor
-                    }
-
-                    integration_config._load_integrations_from_configuration(integrations_configuration)
-
-                    expect(self.integration_config_spy._get_integration_instance).to(
-                        have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                    )
-                    expect(integrations.loaded_integrations).to(have_key('an_integration'))
-
-        with after.each:
-            integration_config._get_integration_instance = self.original_integration_instance_creator
+            with after.each:
+                integration_config._get_integration_instance = self.original_integration_instance_creator

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -55,7 +55,15 @@ with description('the integration_config module'):
                 with context('each configuration contains a module path and a class name'):
                     with it('aborts the program if the either key is missing'):
                         config_dict = {'some_alias': {}}
+                        config_dict_1 = {'some_alias': {'name': 'foo'}}
+                        config_dict_2 = {'some_alias': {'path': 'foo'}}
                         expect(lambda: integration_config._load_custom_integrations_classes(config_dict)).to(
+                            raise_error(SystemExit)
+                        )
+                        expect(lambda: integration_config._load_custom_integrations_classes(config_dict_1)).to(
+                            raise_error(SystemExit)
+                        )
+                        expect(lambda: integration_config._load_custom_integrations_classes(config_dict_2)).to(
                             raise_error(SystemExit)
                         )
 

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -130,12 +130,15 @@ with description('the integration_config module'):
                         integration_config._get_classes_in_module = original_class_finder
 
                     with it('aborts the program if the given class name is not in the module at the specified path'):
+                        original_integration_class_finder = integration_config._get_matching_classobject_from_path
                         integration_config._get_matching_classobject_from_path = lambda a, b: None
 
                         config_dict = {'some_alias': {'path': '/some/path', 'name': 'some_name'}}
                         expect(lambda: integration_config._load_custom_integrations_classes(config_dict)).to(
                             raise_error(SystemExit)
                         )
+
+                        integration_config._get_matching_classobject_from_path = original_integration_class_finder
 
         with context('and a notify section'):
             with before.each:

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -26,7 +26,7 @@ with description('the integration_config module'):
             os.path.isfile = isfile
 
         # PermissonError: [Errno 1] Operation not permitted
-        with _it('exits the program if the file is empty'):
+        with it('exits the program if the file is empty'):
             path = '/tmp/ps' + integration_config.CONFIGURATION_FILE_NAME
             os.mknod(path)
 
@@ -144,22 +144,22 @@ with description('the integration_config module'):
                         )
                         expect(integrations.loaded_integrations).to(have_key('my-alias'))
 
-                with context('when an integration alias is not specified'):
-                    with context('and the integration is configured with one or more parameters'):
-                        with it('requests an integration instance and registers the stock name'):
-                            kwargs_for_integration_constructor = {
-                                'some_arg': 'some_value'
-                            }
-                            integrations_configuration = {'notify': {
-                                'an_integration': kwargs_for_integration_constructor
-                            }}
+            with context('when an integration alias is not specified'):
+                with context('and the integration is configured with one or more parameters'):
+                    with it('requests an integration instance and registers the stock name'):
+                        kwargs_for_integration_constructor = {
+                            'some_arg': 'some_value'
+                        }
+                        integrations_configuration = {'notify': {
+                            'an_integration': kwargs_for_integration_constructor
+                        }}
 
-                            integration_config._load_defined_integrations(integrations_configuration)
+                        integration_config._load_defined_integrations(integrations_configuration)
 
-                            expect(self.integration_config_spy._get_integration_instance).to(
-                                have_been_called_with('an_integration', kwargs_for_integration_constructor).once
-                            )
-                            expect(integrations.loaded_integrations).to(have_key('an_integration'))
+                        expect(self.integration_config_spy._get_integration_instance).to(
+                            have_been_called_with('an_integration', kwargs_for_integration_constructor).once
+                        )
+                        expect(integrations.loaded_integrations).to(have_key('an_integration'))
 
                 with context('and the integration is configured with no parameters'):
                     with it('requests an integration instance and registers the stock name'):

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -67,18 +67,12 @@ with description('the integration_config module'):
 
                 with context('each configuration contains a module path and a class name'):
                     with it('aborts the program if the either key is missing'):
-                        config_dict = {'some_alias': {}}
-                        config_dict_1 = {'some_alias': {'name': 'foo'}}
-                        config_dict_2 = {'some_alias': {'path': 'foo'}}
-                        expect(lambda: integration_config._load_custom_integrations_classes(config_dict)).to(
-                            raise_error(SystemExit)
-                        )
-                        expect(lambda: integration_config._load_custom_integrations_classes(config_dict_1)).to(
-                            raise_error(SystemExit)
-                        )
-                        expect(lambda: integration_config._load_custom_integrations_classes(config_dict_2)).to(
-                            raise_error(SystemExit)
-                        )
+                        for malformed_config_dict in [{'some_alias': {}},
+                                                      {'some_alias': {'name': 'foo'}},
+                                                      {'some_alias': {'path': 'foo'}}]:
+                            expect(lambda: integration_config._load_custom_integrations_classes(malformed_config_dict)).to(
+                                raise_error(SystemExit)
+                            )
 
                     with it('loads the module and finds the class name inside it'):
                         load_modules = loader.load_modules

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -88,7 +88,7 @@ with description('the integration_config module'):
 
                         an_integration_class_object = Spy()
 
-                        loader.load_modules = lambda pth: ['sample_returned_module']
+                        loader.load_modules = lambda path: ['sample_returned_module']
                         integration_config._get_classes_in_module = lambda module: [(an_integration_class_name, an_integration_class_object)]
 
 
@@ -115,7 +115,7 @@ with description('the integration_config module'):
 
                         an_integration_class_object = Spy()
 
-                        loader.load_modules = lambda pth: ['sample_returned_module']
+                        loader.load_modules = lambda path: ['sample_returned_module']
                         integration_config._get_classes_in_module = lambda module: [(an_integration_class_name, an_integration_class_object)]
 
 

--- a/spec/integration_config_spec.py
+++ b/spec/integration_config_spec.py
@@ -43,7 +43,7 @@ with description('the integration_config module'):
                     shutil.rmtree(self.path_to_directory_without_config_file)
 
             with it('raises an exception if the config file is empty'):
-                expect(lambda: integration_config._load_configuration_from_contents_of_config_file('')).to(
+                expect(lambda: integration_config._load_configuration_from_config_file('')).to(
                     raise_error(integration_config.EmptyConfigurationFileError)
                 )
 

--- a/spec/integrations_spec.py
+++ b/spec/integrations_spec.py
@@ -1,6 +1,6 @@
 import rx
 
-from expects import expect, be, contain_exactly, be_a
+from expects import expect, be, contain_exactly, be_a, raise_error
 from doublex import Spy, Mock
 from doublex_expects import have_been_called
 
@@ -35,6 +35,9 @@ with description('the integrations module'):
             on_failure('some_integration')(decorated_function)
 
             expect(decorated_function).to_not(have_been_called)
+
+        with it('aborts the program if it references a non-existent integration'):
+            expect(lambda: integrations._create('bogus_name')).to(raise_error(SystemExit))
 
         with it('has the (convenient) side effect of registering the integration name with a subject'):
             decorated_function = Spy().decorated_function

--- a/spec/integrations_spec.py
+++ b/spec/integrations_spec.py
@@ -5,7 +5,6 @@ from doublex import Spy, Mock
 from doublex_expects import have_been_called
 
 from pysellus import integrations
-from pysellus import integration_config
 from pysellus.integrations import on_failure
 
 
@@ -17,13 +16,13 @@ with description('the integrations module'):
             with Mock() as some_integration_instance:
                 some_integration_instance.get_subject().returns(rx.subjects.Subject())
 
-                integration_config.loaded_integrations = {
+                integrations.loaded_integrations = {
                     'some_integration': some_integration_instance
                 }
 
         with after.each:
             integrations.registered_integrations = {}
-            integration_config.loaded_integrations = {}
+            integrations.loaded_integrations = {}
 
         with it('returns the decorated function as is'):
             decorated_function = Spy().decorated_function

--- a/spec/loader_spec.py
+++ b/spec/loader_spec.py
@@ -6,19 +6,19 @@ from pysellus import loader
 
 with description('the loader module loads all top-level functions in a directory or file'):
     with it('should load every function when there is only one file'):
-        expect(loader.load('spec/fixtures/one_file/')).to(
+        expect(loader.load_test_files('spec/fixtures/one_file/')).to(
             contain_exactly_function_called('a_function',
                                             'another_function')
         )
 
     with it('should load every function of the specified file'):
-        expect(loader.load('spec/fixtures/multiple_files/file_1.py')).to(
+        expect(loader.load_test_files('spec/fixtures/multiple_files/file_1.py')).to(
             contain_exactly_function_called('file_1_function_a',
                                             'file_1_function_b')
         )
 
     with it('should load every function when there is more than one file'):
-        expect(loader.load('spec/fixtures/multiple_files/')).to(
+        expect(loader.load_test_files('spec/fixtures/multiple_files/')).to(
             contain_exactly_function_called('file_1_function_a',
                                             'file_1_function_b',
                                             'file_2_function_a',
@@ -28,6 +28,6 @@ with description('the loader module loads all top-level functions in a directory
         )
 
     with it("should only load setup functions"):
-        expect(loader.load('spec/fixtures/file_with_helper_functions/')).to(
+        expect(loader.load_test_files('spec/fixtures/file_with_helper_functions/')).to(
             contain_exactly_function_called('function')
         )

--- a/spec/slack_spec.py
+++ b/spec/slack_spec.py
@@ -1,13 +1,13 @@
 from expects import expect, be, have_key
 
-from pysellus.stock_integrations import slack, integration_classes
+from pysellus.stock_integrations import slack, stock_integration_classes
 
 
 with description('the slack integration module'):
 
     with it('should be in the integration classes dictionary'):
-        expect(integration_classes).to(have_key('slack'))
-        expect(integration_classes['slack']).to(be(slack.SlackIntegration))
+        expect(stock_integration_classes).to(have_key('slack'))
+        expect(stock_integration_classes['slack']).to(be(slack.SlackIntegration))
 
     with it('should initialize with the correct arguments'):
         slack_url = 'an_url'


### PR DESCRIPTION
The syntax to add a new custom integration is as follows:

``` yaml
custom_integrations:
    your_integration_name:
        path: "/absolute/path/to/integration/file"
        name: "NameOfIntegrationClass"
```

For each custom integration, the user should supply the path of the
integration file, and the name of the class containing the integration
inside the file (that would be the class inheriting from
AbstractIntegration).

The program will abort if no matching class is found inside the given
file.

Still pending: add tests
